### PR TITLE
libccp: update to new libccp api without global state

### DIFF
--- a/ccp_nl.c
+++ b/ccp_nl.c
@@ -5,6 +5,7 @@
 
 ccp_nl_recv_handler ccp_msg_reader = NULL;
 struct sock *nl_sk;
+extern struct ccp_datapath *kernel_datapath;
 
 // callback from userspace ccp
 // all messages will be PatternMsg OR InstallFoldMsg
@@ -23,7 +24,7 @@ void nl_recv(struct sk_buff *skb) {
     //}
     //printk(KERN_INFO "]\n");
 
-    ok = ccp_msg_reader((char*)nlmsg_data(nlh), nlh->nlmsg_len);
+    ok = ccp_msg_reader(kernel_datapath, (char*)nlmsg_data(nlh), nlh->nlmsg_len);
     if (ok < 0) {
         pr_info("message read failed: %d.\n", ok);
     }
@@ -50,7 +51,6 @@ void free_ccp_nl_sk(void) {
 
 // send IPC message to userspace ccp
 int nl_sendmsg(
-    struct ccp_datapath *dp,
     struct ccp_connection *conn,
     char *msg, 
     int msg_size

--- a/ccp_nl.h
+++ b/ccp_nl.h
@@ -8,7 +8,7 @@
 
 #include "libccp/ccp.h"
 
-typedef int (*ccp_nl_recv_handler)(char *msg, int msg_size);
+typedef int (*ccp_nl_recv_handler)(struct ccp_datapath *datapath, char *msg, int msg_size);
 
 /* Create a netlink kernel socket
  * A global (struct sock*), ccp_nl_sk, will get set so we can use the socket
@@ -23,7 +23,6 @@ void free_ccp_nl_sk(void);
 /* Send serialized message to userspace CCP
  */
 int nl_sendmsg(
-    struct ccp_datapath *dp,
     struct ccp_connection *conn,
     char *msg, 
     int msg_size

--- a/ccpkp/ccpkp.c
+++ b/ccpkp/ccpkp.c
@@ -239,7 +239,6 @@ void ccpkp_try_read(void) {
 }
 
 int ccpkp_sendmsg(
-        struct ccp_datapath *dp,
         struct ccp_connection *conn,
         char *buf,
         int bytes_to_write

--- a/ccpkp/ccpkp.h
+++ b/ccpkp/ccpkp.h
@@ -31,7 +31,7 @@ ssize_t     ccpkp_user_read(struct file *fp, char *buf, size_t bytes_to_read, lo
 void        ccpkp_try_read(void);
 ssize_t     ccpkp_kernel_read(struct kpipe *pipe, char *buf, size_t bytes_to_read);
 ssize_t     ccpkp_user_write(struct file *fp, const char *buf, size_t bytes_to_write, loff_t *offset);
-int         ccpkp_sendmsg(struct ccp_datapath *dp, struct ccp_connection *conn, char *buf, int bytes_to_write);
+int         ccpkp_sendmsg(struct ccp_connection *conn, char *buf, int bytes_to_write);
 ssize_t     ccpkp_kernel_write(struct kpipe *pipe, const char *buf, size_t bytes_to_read, int id);
 int         ccpkp_user_release(struct inode *, struct file *);
 void        ccpkp_cleanup(void);

--- a/tcp_ccp.c
+++ b/tcp_ccp.c
@@ -450,7 +450,6 @@ static int __init tcp_ccp_register(void) {
     pr_info("[ccp] ipc =  %s unknown\n", __IPC__);
     return -3;
 #endif
-
 	
     ok = ccp_init(kernel_datapath);
     if (ok < 0) {
@@ -462,14 +461,16 @@ static int __init tcp_ccp_register(void) {
 }
 
 static void __exit tcp_ccp_unregister(void) {
-    pr_info("[ccp] exit\n");
-    ccp_free(kernel_datapath);
     tcp_unregister_congestion_control(&tcp_ccp_congestion_ops);
 #if __IPC__ == IPC_NETLINK
     free_ccp_nl_sk();
 #elif __IPC__ == IPC_CHARDEV
     ccpkp_cleanup();
 #endif
+    kfree(kernel_datapath->programs);
+    kfree(kernel_datapath->ccp_active_connections);
+    kfree(kernel_datapath);
+    pr_info("[ccp] exit\n");
 }
 
 module_init(tcp_ccp_register);

--- a/tcp_ccp.c
+++ b/tcp_ccp.c
@@ -1,6 +1,5 @@
 #include "tcp_ccp.h"
 #include "libccp/ccp.h"
-#include "libccp/ccp_priv.h"
 
 #if __KERNEL_VERSION_MINOR__ <= 14 && __KERNEL_VERSION_MINOR__ >= 13
 #define COMPAT_MODE
@@ -410,6 +409,7 @@ static int __init tcp_ccp_register(void) {
         pr_info("[ccp] could not allocate ccp_datapath\n");
         return -4;
     }
+
     kernel_datapath->max_connections = MAX_ACTIVE_FLOWS;
     kernel_datapath->ccp_active_connections =
         (struct ccp_connection *) kmalloc(sizeof(struct ccp_connection) * MAX_ACTIVE_FLOWS, GFP_KERNEL);
@@ -417,13 +417,8 @@ static int __init tcp_ccp_register(void) {
         pr_info("[ccp] could not allocate ccp_active_connections\n");
         return -5;
     }
+
     kernel_datapath->max_programs = MAX_DATAPATH_PROGRAMS;
-    kernel_datapath->programs =
-        (struct DatapathProgram *) kmalloc(sizeof(struct DatapathProgram) * MAX_DATAPATH_PROGRAMS, GFP_KERNEL);
-    if(!kernel_datapath->programs) {
-        pr_info("[ccp] could not allocate list of datapath programs\n");
-        return -5;
-    }
     kernel_datapath->set_cwnd = &do_set_cwnd;
     kernel_datapath->set_rate_abs = &do_set_rate_abs;
     kernel_datapath->now = &ccp_now;
@@ -467,7 +462,6 @@ static void __exit tcp_ccp_unregister(void) {
 #elif __IPC__ == IPC_CHARDEV
     ccpkp_cleanup();
 #endif
-    kfree(kernel_datapath->programs);
     kfree(kernel_datapath->ccp_active_connections);
     kfree(kernel_datapath);
     pr_info("[ccp] exit\n");

--- a/tcp_ccp.h
+++ b/tcp_ccp.h
@@ -7,6 +7,9 @@
 
 #define MAX_SKB_STORED 50
 
+#define MAX_ACTIVE_FLOWS 1024
+#define MAX_DATAPATH_PROGRAMS 10
+
 struct skb_info {
     u64 first_tx_mstamp; // choose the correct skb so the timestamp for first packet
     u32 interval_us; // interval us as calculated from this SKB
@@ -20,7 +23,7 @@ struct ccp {
     struct skb_info *skb_array; // array of future skb information
 
     // communication
-    struct ccp_connection *dp;
+    struct ccp_connection *conn;
 };
 
 #define MTU 1500


### PR DESCRIPTION
This PR updates ccp-kernel to use the slightly modified libccp api that does not rely on global state. This change was only necessary for other datapaths that internally use multiple threads. For this datapath, it essentially just moves the global state to be in the namespace of the kernel module as opposed to within libccp. 

This should be merged AFTER https://github.com/ccp-project/libccp/pull/48, and should be updated to use the correct commit hash if it changes within libccp. 