### PR TITLE
Fix the "start connection failed" bug.

### DIFF
--- a/tcp_ccp.c
+++ b/tcp_ccp.c
@@ -421,8 +421,9 @@ static int __init tcp_ccp_register(void) {
     }
 
     kernel_datapath->max_connections = MAX_ACTIVE_FLOWS;
+    // initializes ccp_active_connections to zeros to support the availability check using index == 0 in ccp_connection_start()
     kernel_datapath->ccp_active_connections =
-        (struct ccp_connection *) kmalloc(sizeof(struct ccp_connection) * MAX_ACTIVE_FLOWS, GFP_KERNEL);
+        (struct ccp_connection *) kzalloc(sizeof(struct ccp_connection) * MAX_ACTIVE_FLOWS, GFP_KERNEL);
     if(!kernel_datapath->ccp_active_connections) {
         pr_info("[ccp] could not allocate ccp_active_connections\n");
         return -5;


### PR DESCRIPTION
I run into [this issue](https://github.com/ccp-project/ccp-kernel/issues/21) when I was trying to reproduce bbr's result, and I believe the reason is the incompatible usage of conn->index for availability check with the initialization. Specifically, in ccp_connection_start():

```
    // scan to find empty place
    // index = 0 means free/unused
    for (sid = 0; sid < datapath->max_connections; sid++) {
        conn = &datapath->ccp_active_connections[sid];
        if (CAS(&(conn->index), 0, sid+1)) {
            sid = sid + 1;
            break;
        }
    }
    
    if (sid >= datapath->max_connections) {
        return NULL;
    }
```

the uninitialized index is assumed to be 0, which is not necessarily true when only kmalloc is used for the active connections. The following patch should solve the issue, which is also more concise than the proposal in issue 21.
